### PR TITLE
added Xcode 5 compatibility flags

### DIFF
--- a/JDPluginManager/Info.plist
+++ b/JDPluginManager/Info.plist
@@ -26,5 +26,10 @@
 	<true/>
 	<key>XCPluginHasUI</key>
 	<false/>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This seems to be all it takes to make the plugin work under XCode 5 (GM)
